### PR TITLE
TC 10.3.1_03 Verify 'Create New Customer Account' page presents an em…

### DIFF
--- a/tests/createNewCustomer.spec.js
+++ b/tests/createNewCustomer.spec.js
@@ -1,0 +1,18 @@
+import { test, expect} from "@playwright/test"; 
+
+test.describe('Create New Customer page', () => {
+
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/');
+    });
+
+    test.only('Verify Create New Customer Account page presents an empty forms for Personal Information and Sign-in Information', async ({ page }) => {
+        await page.getByRole('link', {name: 'Create an Account'}).click();
+
+        await expect(page.locator('#firstname')).toBeEmpty();
+        await expect(page.locator('#lastname')).toBeEmpty();
+        await expect(page.locator('#email_address')).toBeEmpty();
+        await expect(page.locator('.field.password.required .control #password')).toBeEmpty();
+        await expect(page.locator('#password-confirmation')).toBeVisible();
+    });
+});

--- a/tests/createNewCustomer.spec.js
+++ b/tests/createNewCustomer.spec.js
@@ -6,7 +6,7 @@ test.describe('Create New Customer page', () => {
         await page.goto('/');
     });
 
-    test.only('Verify Create New Customer Account page presents an empty forms for Personal Information and Sign-in Information', async ({ page }) => {
+    test('Verify Create New Customer Account page presents an empty forms for Personal Information and Sign-in Information', async ({ page }) => {
         await page.getByRole('link', {name: 'Create an Account'}).click();
 
         await expect(page.locator('#firstname')).toBeEmpty();


### PR DESCRIPTION
https://trello.com/c/ueO2DomS/197-tc-103103-verify-create-new-customer-account-page-presents-a-clear-form-for-entering-personal-and-sign-in-information