### PR TITLE
TC 04.5.1_03 <Menu/Training> Verify that the promo block is displayed on the “Training” page

### DIFF
--- a/tests/menuTraining.spec.js
+++ b/tests/menuTraining.spec.js
@@ -31,4 +31,12 @@ test.describe('menuTraining', () => {
 		expect(page.locator('.breadcrumbs li:nth-child(2)')).toBeTruthy();
 		
   })
+   test('Verify that the promo block is displayed on the “Training” page', async({page}) => {
+		        
+		await page.getByRole('menuitem', { name: 'Training' }).click();
+
+		await expect(page.locator('.blocks-promo')).toBeVisible();
+		expect(page.locator('.blocks-promo')).toBeTruthy();
+  })
+
 })


### PR DESCRIPTION
https://trello.com/c/Zm0qOpRK/216-tc-045103-menu-training-verify-that-the-promo-block-is-displayed-on-the-training-page