### PR TITLE
TC 04.5.1_04 <Menu/Training> Verify that the "Shop By Category" section is displayed on the “Training” page

### DIFF
--- a/tests/menuTraining.spec.js
+++ b/tests/menuTraining.spec.js
@@ -38,5 +38,14 @@ test.describe('menuTraining', () => {
 		await expect(page.locator('.blocks-promo')).toBeVisible();
 		expect(page.locator('.blocks-promo')).toBeTruthy();
   })
+   test('Verify that the "Shop By Category" section is displayed on the “Training” page', async({page}) => {
+		        
+		await page.getByRole('menuitem', { name: 'Training' }).click();
+
+		const locatorSection = page.getByText('Shop By Shopping Options');
+
+		await expect(locatorSection).toBeVisible();
+		expect(locatorSection).toBeTruthy();
+  })
 
 })


### PR DESCRIPTION
https://trello.com/c/7xol21ST/217-tc-045104-menu-training-verify-that-the-shop-by-category-section-is-displayed-on-the-training-page