### PR TITLE
add shop new yoga collection test

### DIFF
--- a/tests/pageWomen.spec.js
+++ b/tests/pageWomen.spec.js
@@ -16,4 +16,11 @@ test.describe("Checking Promo blocks on page 'Women'", () => {
 
     await expect(page).toHaveURL('https://magento.softwaretestingboard.com/women/bottoms-women/pants-women.html');
   })  
+
+  test.fail('click Promo link', async ({page}) => {//has to fail because there's a bug on the page
+    await page.getByText('Shop New Yoga').click();
+
+    await expect(page).toHaveURL('https://magento.softwaretestingboard.com/collections/yoga-new.html')
+    await expect(page).locator('.page-title-heading').toHaveText('New Luma Yoga Collection') 
+  })
 });


### PR DESCRIPTION
TC 04.2.3_3 Menu/Women/Promo Block Navigate to New Luma Yoga Collection page by clicking Promo link on 'Women' page

This test has to fail because the button doesn't take the user to the required page but sends them back to women>promo page