### PR TITLE
Fixed - TC 04.6.2_01 Verify "Sale" page contains 6 promo-blocks in body part

### DIFF
--- a/tests/menuSalePromo-block.spec.js
+++ b/tests/menuSalePromo-block.spec.js
@@ -14,10 +14,10 @@ test.describe("menuSalePromo-block", () => {
 
   });
 
-  test.skip("Verify 'Sale' page contains 6 promo-blocks as images", async ({ page }) => {
-    const promoBlocks = page.locator("div.blocks-promo img");
+  test("Verify 'Sale' page contains 6 promo-blocks in body part", async ({ page }) => {
+    const promoBlocks = page.locator("main a.block-promo");
 
-    expect(promoBlocks).toHaveCount(6);
+    await expect(promoBlocks).toHaveCount(6);
   });
 
   for (const link of links) {


### PR DESCRIPTION
https://trello.com/c/hvfpMwoB/413-err-menusalepromo-blockspec-verify-sale-page-contains-6-promo-blocks-as-images