### PR TITLE
ERR | purchaseFlowShoppingCart.spec.js | page checkout/cart › should …

### DIFF
--- a/tests/purchaseFlowShoppingCart.spec.js
+++ b/tests/purchaseFlowShoppingCart.spec.js
@@ -70,13 +70,13 @@ test.describe('page checkout/cart', () => {
     await page.waitForTimeout(3000);
     await expect(page.getByRole('heading', { name: 'Estimate Shipping and Tax ' })).toBeTruthy();
 
-    await page.getByRole('tab', { name: 'Estimate Shipping and Tax' }).click();
+    // await page.getByRole('tab', { name: 'Estimate Shipping and Tax' }).click();
 
     const countrySelector = 'Country';
     await page.locator(`label:has-text("${countrySelector}") + select`, 'United States');
     await expect(page.locator(`label:has-text("${countrySelector}") + select`, 'United States')).toBeTruthy();
 
-    await page.getByRole('tab', { name: 'Estimate Shipping and Tax' }).click();
+    // await page.getByRole('tab', { name: 'Estimate Shipping and Tax' }).click();
 
 
     await page.locator('select[name="region_id"]').click()
@@ -118,7 +118,7 @@ test.describe('page checkout/cart', () => {
     await expect(page.locator(`label:has-text("${countrySelector}") + select`, 'United States')).toBeTruthy();
 
     await page.waitForTimeout(3000);
-    
+
     await page.getByRole('tab', { name: 'Estimate Shipping and Tax' }).click();
 
     await page.locator('select[name="region_id"]').click()
@@ -131,5 +131,7 @@ test.describe('page checkout/cart', () => {
     await expect(page).toHaveURL('https://magento.softwaretestingboard.com/checkout/#shipping');
 
   })
+
+
 
 })


### PR DESCRIPTION
https://trello.com/c/DJKho3lq/516-err-purchaseflowshoppingcartspecjs-page-checkout-cart-should-be-cost-is-displayed-at-the-bottom-of-the-summary