### PR TITLE
RF_POM |homePage.spec | TC 01.2.1_02 Verify user doesn't receive the results when make search with invalid text

### DIFF
--- a/helpers/testData.js
+++ b/helpers/testData.js
@@ -51,7 +51,10 @@ export const THANKS_MESSAGE = 'Thank you for registering with Main Website Store
 export const EXPECTED_ITEM_STYLE_WOMEN_BOTTOMS = ['Base Layer', 'Basic', 'Capri', 'Compression', 'Leggings', 'Parachute', 'Snug', 'Sweatpants', 'Track Pants'];
 
 export const SEARCH_VALID_VALUE = 'jacket';
+export const SEARCH_INVALID_VALUE = `${SEARCH_VALID_VALUE}test`;
 export const SEARCH_RESULTS_JACKET_HEADER = `Search results for: '${SEARCH_VALID_VALUE}'`;
+export const WARNING_MESSAGE_NO_RESULTS = ' Your search returned no results. ';
+export const ITEMS = ' Items ';
 
 export const LIST_STYLE_MEN_TOPS = [
     'Insulated',

--- a/page_objects/searchNoResultsPage.js
+++ b/page_objects/searchNoResultsPage.js
@@ -1,0 +1,14 @@
+import {WARNING_MESSAGE_NO_RESULTS, ITEMS} from "../helpers/testData";
+
+class SearchNoResultsPage {
+    constructor(page){
+        this.page = page;
+    }
+
+    locators = {
+        getWarningMessageNoResults: () => this.page.locator('.message.notice').getByText(WARNING_MESSAGE_NO_RESULTS),
+        getNoResultsInfo: () => this.page.locator('#toolbar-amount').getByText(ITEMS)
+    }
+}
+
+export default SearchNoResultsPage;

--- a/tests/test_page_objects/homePage.spec.js
+++ b/tests/test_page_objects/homePage.spec.js
@@ -1,8 +1,9 @@
 import { test, expect } from "@playwright/test";
 import HomePage from "../../page_objects/homePage.js";
-import { BASE_URL, WHATS_NEW_PAGE_END_POINT, WHATS_NEW_PAGE_HEADER, SEARCH_QUERY, SEARCH_QUERY_UPPERCASE, SEARCH_RESULTS_JACKET_PAGE_END_POINT, SEARCH_VALID_VALUE, SEARCH_RESULTS_JACKET_HEADER, RADIANT_TEE_PAGE_END_POINT} from "../../helpers/testData.js";
+import { BASE_URL, WHATS_NEW_PAGE_END_POINT, WHATS_NEW_PAGE_HEADER, SEARCH_QUERY, SEARCH_QUERY_UPPERCASE, SEARCH_RESULTS_JACKET_PAGE_END_POINT, SEARCH_VALID_VALUE, SEARCH_RESULTS_JACKET_HEADER, RADIANT_TEE_PAGE_END_POINT, SEARCH_INVALID_VALUE, WARNING_MESSAGE_NO_RESULTS} from "../../helpers/testData.js";
 import SearchResultsJacketPage from "../../page_objects/searchResultsJacketPage.js";
 import RadiantTeePage from "../../page_objects/radiantTeePage.js";
+import SearchNoResultsPage from "../../page_objects/searchNoResultsPage.js";
 
 test.describe('homePage.spec', () => {
     test.beforeEach(async ({ page }) => {
@@ -88,5 +89,17 @@ test.describe('homePage.spec', () => {
 
         await expect(page).toHaveURL(BASE_URL + RADIANT_TEE_PAGE_END_POINT);
         await expect(radiantTeePage.locators.getRadiantTeeHeader()).toBeVisible();
-    })
+    });
+
+    test('Verify user doesn`t receive the results when make search with invalid text ', async({page}) => {
+        
+        const homePage = new HomePage(page);
+        const searchNoResultsPage = new SearchNoResultsPage(page);
+        
+        await homePage.fillSearchInputField(SEARCH_INVALID_VALUE);
+        await homePage.locators.getSearchButton().click();
+        await expect(searchNoResultsPage.locators.getWarningMessageNoResults()).toHaveText(WARNING_MESSAGE_NO_RESULTS);
+        await expect(searchNoResultsPage.locators.getNoResultsInfo()).toBeHidden();
+    });
+
 })


### PR DESCRIPTION
https://trello.com/c/cjimAZ1k/612-rfpom-homepagespec-tc-012102-verify-user-doesnt-receive-the-results-when-make-search-with-invalid-text