### PR TITLE
RF_POM | ordersAndReturnsPage.spec.js |TC 02.4.2_01 <Footer/Orders and Returns/page>Verify header "Orders and Returns" is displayed on the "Orders and Returns" page

### DIFF
--- a/helpers/testData.js
+++ b/helpers/testData.js
@@ -141,6 +141,7 @@ export const LIST_OF_MATERIALS_SUBITEMS_EXPECTED = [
   ];
 
 export const JACKET_ITEMS = ["Jacket", "Shell"];
+export const ORDERS_AND_RETURNS_HEADER = 'Orders and Returns';
 
 //login  credential
 

--- a/page_objects/homePage.js
+++ b/page_objects/homePage.js
@@ -13,6 +13,7 @@ import GearWatchesPage from "./gearWatchesPage.js";
 import Footer from "./footer.js";
 import GearPage from "./gearPage.js";
 import GearBagsPage from "./gearBagsPage.js";
+import OrdersAndReturnsPage from "./ordersAndReturnsPage.js";
 class HomePage {
   constructor(page) {
     this.page = page;
@@ -67,6 +68,7 @@ class HomePage {
       this.page.getByRole("menuitem", { name: "Watches" }),
     getFirstCardName: () => this.page.locator('a[title="Radiant Tee"]'),
     getNavigationMenuItemsList: () => this.page.getByRole('navigation').getByRole('listitem'),
+    getOrdersAndReturnsLink: () => this.page.locator('.page-wrapper footer li:has-text("Orders and Returns")'),
   };
 
   async open() {
@@ -244,6 +246,11 @@ class HomePage {
 	await this.locators.getGearBagsSubmenuItem().click();
 
 	return new GearBagsPage(this.page);
+}
+  async clickOrdersAndReturnsLink() {
+    await this.locators.getOrdersAndReturnsLink().click();
+
+    return new OrdersAndReturnsPage(this.page);
 }
 }
 export default HomePage;

--- a/page_objects/ordersAndReturnsPage.js
+++ b/page_objects/ordersAndReturnsPage.js
@@ -1,0 +1,10 @@
+class OrdersAndReturnsPage {
+    constructor (page) {
+        this.page = page
+    }
+  
+    locators = {
+        getOrdersAndReturnsHeader: () => this.page.locator("h1"),
+    }
+  }
+  export default OrdersAndReturnsPage;

--- a/tests/test_page_objects/ordersAndReturnsPage.spec.js
+++ b/tests/test_page_objects/ordersAndReturnsPage.spec.js
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+import HomePage from '../../page_objects/homePage.js';
+import OrdersAndReturnsPage from '../../page_objects/ordersAndReturnsPage.js';
+import { ORDERS_AND_RETURNS_HEADER } from '../../helpers/testData.js';
+
+test.describe('ordersAndReturnsPage.spec', () => {
+    test.beforeEach(async ({page}) => {
+        const homePage = new HomePage(page);
+
+        await homePage.open();   
+    })
+
+    test('<Footer/Orders and Returns/page>Verify header "Orders and Returns" is displayed on the "Orders and Returns" page', async ({page}) => {
+        const homePage = new HomePage(page);
+        const ordersAndReturnsPage = await homePage.clickOrdersAndReturnsLink();
+
+        await expect(ordersAndReturnsPage.locators.getOrdersAndReturnsHeader()).toHaveText(ORDERS_AND_RETURNS_HEADER);
+        await expect(ordersAndReturnsPage.locators.getOrdersAndReturnsHeader()).toBeVisible();
+    })
+})


### PR DESCRIPTION
https://trello.com/c/7DtkltCv/629-rfpom-headerspecjs-placeholder