### PR TITLE
ERR | Verify that ${name} from material options list is visible and has right name

### DIFF
--- a/page_objects/gearBagsPage.js
+++ b/page_objects/gearBagsPage.js
@@ -48,6 +48,7 @@ class GearBagsPage {
 
     async clickMaterialOption() {
         await this.locators.getMaterialOption().click();
+        await this.locators.getMateialLeather().waitFor();
 
         return this;
     }

--- a/tests/test_page_objects/gearBags.spec.js
+++ b/tests/test_page_objects/gearBags.spec.js
@@ -22,7 +22,7 @@ test.describe('gearBags.spec', () => {
     }) 
     
     MATERIAL_OPTION_NAMES.forEach((name, idx) => {
-        test.skip(`Verify that ${name} from material options list is visible and has right name`, async ({ page }) => {
+        test(`Verify that ${name} from material options list is visible and has right name`, async ({ page }) => {
             const gearBagsPage = new GearBagsPage(page);
 
             await gearBagsPage.clickMaterialOption();


### PR DESCRIPTION
Cannot repeat an error locally but added waitFor() in click method to prevent test falling in the future

https://trello.com/c/g8KYxl7i/747-err-gearbagsspec-verify-that-name-from-material-options-list-is-visible-and-has-right-name